### PR TITLE
Prep for initial release

### DIFF
--- a/.github/workflows/deno-ci.yml
+++ b/.github/workflows/deno-ci.yml
@@ -31,9 +31,9 @@ jobs:
         run: deno task test
 
       - name: Generate CodeCov-friendly coverage report
-        run: deno task coverage --lcov --output=codecov.lcov
+        run: deno task coverage
 
       - name: Upload coverage to CodeCov
         uses: codecov/codecov-action@v3.1.0
         with:
-          file: ./codecov.lcov
+          file: ./lcov.info

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -38,36 +38,17 @@ export const MessageBoundaryProtocol = function (args: string[]): Protocol {
     args,
   );
   if (!boundary) throw new Error("no boundary argument provided!");
-  const originalConsole = {
-    log: globalThis.console.log,
-    warn: globalThis.console.warn,
-    error: globalThis.console.error,
-  };
   const protocol = {
     name: MSG_BOUNDARY_PROTOCOL,
     log: console.log,
-    // TODO: `error` could just as easily remain as console.error (i.e stderr) - BUT - we need to ensure that on the CLI side, we stream hook stderr out straight to the user
-    // TODO: if we override default console.error functionality (as below), then we also need to implement the `install()` and `uninstall()` methods
-    // TODO: `install()` and `uninstall()` would 'clobber' `globalThis.console` methods with these methods, to ensure that any userland or SDK code
-    //       does not litter stdout in ways that violate the protocol's rules.
-    error: console.log,
-    warn: console.log, // TODO: same as previous line
+    error: console.error,
+    warn: console.warn,
     // deno-lint-ignore no-explicit-any
     respond: (data: any) => {
       console.log(boundary + data + boundary);
     },
     getCLIFlags:
       () => [`--protocol=${MSG_BOUNDARY_PROTOCOL}`, `--boundary=${boundary}`],
-    install: () => {
-      globalThis.console.log = protocol.log;
-      globalThis.console.error = protocol.error;
-      globalThis.console.warn = protocol.warn;
-    },
-    uninstall: () => {
-      globalThis.console.log = originalConsole.log;
-      globalThis.console.error = originalConsole.error;
-      globalThis.console.warn = originalConsole.warn;
-    },
   };
   return protocol;
 };


### PR DESCRIPTION
###  Summary

Initial implementation: 

- adds a `Protocol` interface describing the main protocol for communication with the CLI.
- implements two `Protocol`s: the default, base one in use today, and the next message-boundary-based one we hope to roll out soon.
- `getProtocolInterface()` encapsulates protocol resolution.

Other:

- Removing any clobbering of `console` methods from the `MessageBoundaryProtocol`

For an example of how other deno libraries would consume this library, see this [deno-slack-hooks PR](https://github.com/slackapi/deno-slack-hooks/pull/57); most of the hook implementations (e.g. `src/build.ts`, `src/check_update.ts`, `src/get_manifest.ts`).