### PR TITLE
Format docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # deno-slack-protocols
 
-This library is a utility for use by Slack's next-generation application platform, focused on remixable
-units of functionality encapsulated as ephemeral functions. It implements the rules for communication (i.e. the protocol)
-between [Slack CLI][cli] and any Slack app development SDKs.
+This library is a utility for use by Slack's next-generation application
+platform, focused on remixable units of functionality encapsulated as ephemeral
+functions. It implements the rules for communication (i.e. the protocol) between
+[Slack CLI][cli] and any Slack app development SDKs.
 
-This is separate from the [deno-slack-hooks][hooks] project, which implements the various APIs encapsulating
-work delegation from the CLI to the SDK. The [deno-slack-hooks][hooks] project implements the API, which uses this
-library under the hood.
+This is separate from the [deno-slack-hooks][hooks] project, which implements
+the various APIs encapsulating work delegation from the CLI to the SDK. The
+[deno-slack-hooks][hooks] project implements the API, which uses this library
+under the hood.
 
 ## Requirements
 
-This library requires a recent (at least 1.22) version of [deno](https://deno.land).
+This library requires a recent (at least 1.22) version of
+[deno](https://deno.land).
 
 ## Running Tests
 
-If you make changes to this repo, or just want to make sure things are working as desired, you can run:
+If you make changes to this repo, or just want to make sure things are working
+as desired, you can run:
 
     deno task test
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
   "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
   "fmt": {
     "files": {
-      "include": ["src"]
+      "include": ["src", "docs", "README.md"]
     },
     "options": {
       "semiColons": true,


### PR DESCRIPTION
###  Summary

This PR adds `docs` directory and the `README` to the `fmt.files.include` portion of the `deno.jsonc` and runs the formatter.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
