### PR TITLE
Split out health score as separate job that runs after test

### DIFF
--- a/.github/workflows/deno-ci.yml
+++ b/.github/workflows/deno-ci.yml
@@ -40,6 +40,8 @@ jobs:
     permissions:
       checks: write
     steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
       - name: Report health score
         uses: slackapi/slack-health-score@v0
         with:

--- a/.github/workflows/deno-ci.yml
+++ b/.github/workflows/deno-ci.yml
@@ -17,29 +17,29 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
     steps:
       - name: Setup repo
         uses: actions/checkout@v4
-
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-
       - name: Run tests
         run: deno task test
-
       - name: Generate CodeCov-friendly coverage report
         run: deno task generate-lcov
-
       - name: Upload coverage to CodeCov
         uses: codecov/codecov-action@v4
         with:
           file: ./lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
 
-          
+  health-score:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      checks: write
+    steps:
       - name: Report health score
         uses: slackapi/slack-health-score@v0
         with:


### PR DESCRIPTION
also explicitly give check-writing permissions to this job, as health-score needs it.

needed for dependabot: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions