### PR TITLE
chore: update CI to support Deno 2

### DIFF
--- a/.github/workflows/deno-ci.yml
+++ b/.github/workflows/deno-ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: deno task generate-lcov
       - name: Upload coverage to CodeCov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
-        if: ${{ matrix.deno-version }} == 'v2.x'
+        if: matrix.deno-version == 'v2.x'
         with:
           files: ./lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Summary

This PR update the CI pipeline so that tests are ran against Deno 2 as well as Deno 1

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
